### PR TITLE
Add utils from Shopify/shopify-monitoring-api

### DIFF
--- a/utils/chunk.go
+++ b/utils/chunk.go
@@ -1,0 +1,23 @@
+package utils
+
+// Chunk takes an input array of T elements, and "chunks" into groups of chunkSize elements.
+// If the input array is empty, or the batchSize is 0, return an empty slice of slices.
+// Adapted to generics from https://github.com/golang/go/wiki/SliceTricks#batching-with-minimal-allocation.
+// Examples:
+// Chunk([]int{1, 2, 3, 4, 5}, 2) = [[1, 2] [3, 4], [5]]
+// Chunk([]int{}, 2) = []
+// Chunk([]int{1, 2, 3}, 0) = [].
+func Chunk[T any](actions []T, batchSize int) [][]T {
+	// if the input is empty or batch size is 0, return an empty slice of slices
+	if len(actions) == 0 || batchSize < 1 {
+		return [][]T{}
+	}
+	// make out as a new slice of type T slices, up to the max number of chunks in the result
+	batches := make([][]T, 0, (len(actions)+batchSize-1)/batchSize)
+
+	for batchSize < len(actions) {
+		actions, batches = actions[batchSize:], append(batches, actions[0:batchSize:batchSize])
+	}
+	batches = append(batches, actions)
+	return batches
+}

--- a/utils/chunk_test.go
+++ b/utils/chunk_test.go
@@ -1,0 +1,116 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChunkInts(t *testing.T) {
+	type TestCase struct {
+		Input          []int
+		ChunkSize      int
+		ExpectedOutput [][]int
+		Message        string
+	}
+
+	testCases := []TestCase{
+		{
+			Input:          []int{1, 2, 3, 4, 5},
+			ChunkSize:      2,
+			ExpectedOutput: [][]int{{1, 2}, {3, 4}, {5}},
+			Message:        "5 elements, chunk size 2",
+		},
+		{
+			Input:          []int{5, 2, 4, 1, 3},
+			ChunkSize:      2,
+			ExpectedOutput: [][]int{{5, 2}, {4, 1}, {3}},
+			Message:        "5 elements, chunk size 2, order preserved",
+		},
+		{
+			Input:          []int{1, 2, 3, 4, 5},
+			ChunkSize:      5,
+			ExpectedOutput: [][]int{{1, 2, 3, 4, 5}},
+			Message:        "5 elements, chunk size 5",
+		},
+		{
+			Input:          []int{1, 2, 3, 4, 5},
+			ChunkSize:      500,
+			ExpectedOutput: [][]int{{1, 2, 3, 4, 5}},
+			Message:        "5 elements, chunk size 500",
+		},
+		{
+			Input:          []int{1},
+			ChunkSize:      2,
+			ExpectedOutput: [][]int{{1}},
+			Message:        "1 elements, chunk size 2",
+		},
+		{
+			Input:          []int{1},
+			ChunkSize:      0,
+			ExpectedOutput: [][]int{},
+			Message:        "1 element array, chunk size 0",
+		},
+		{
+			Input:          []int{},
+			ChunkSize:      2,
+			ExpectedOutput: [][]int{},
+			Message:        "empty array, chunk size 2",
+		},
+	}
+
+	for _, testCase := range testCases {
+		output := Chunk(testCase.Input, testCase.ChunkSize)
+		require.Equal(t, testCase.ExpectedOutput, output, testCase.Message)
+	}
+}
+
+func TestChunkStrings(t *testing.T) {
+	type TestCase struct {
+		Input          []string
+		ChunkSize      int
+		ExpectedOutput [][]string
+		Message        string
+	}
+
+	testCases := []TestCase{
+		{
+			Input:          []string{"a", "b", "c"},
+			ChunkSize:      2,
+			ExpectedOutput: [][]string{{"a", "b"}, {"c"}},
+			Message:        "3 elements, chunk size 2",
+		},
+	}
+
+	for _, testCase := range testCases {
+		output := Chunk(testCase.Input, testCase.ChunkSize)
+		require.Equal(t, testCase.ExpectedOutput, output, testCase.Message)
+	}
+}
+
+func TestChunkStructs(t *testing.T) {
+	type ExampleStruct struct {
+		Foo string
+	}
+
+	type TestCase struct {
+		Input          []ExampleStruct
+		ChunkSize      int
+		ExpectedOutput [][]ExampleStruct
+		Message        string
+	}
+
+	testCases := []TestCase{
+		{
+			Input:          []ExampleStruct{{Foo: "a"}, {Foo: "b"}, {Foo: "c"}},
+			ChunkSize:      2,
+			ExpectedOutput: [][]ExampleStruct{{{Foo: "a"}, {Foo: "b"}}, {{Foo: "c"}}},
+			Message:        "3 elements, chunk size 2",
+		},
+	}
+
+	for _, testCase := range testCases {
+		output := Chunk(testCase.Input, testCase.ChunkSize)
+		require.Equal(t, testCase.ExpectedOutput, output, testCase.Message)
+	}
+}

--- a/utils/errorStrings.go
+++ b/utils/errorStrings.go
@@ -1,0 +1,8 @@
+package utils
+
+// ErrorStrings is a convenience function to convert an array of errors to error strings.
+func ErrorStrings(errs []error) []string {
+	return Map(errs, func(err error) string {
+		return err.Error()
+	})
+}

--- a/utils/fill.go
+++ b/utils/fill.go
@@ -1,0 +1,9 @@
+package utils
+
+func Fill[T any](t T, num int) []T {
+	out := make([]T, 0, num)
+	for i := 0; i < num; i++ {
+		out = append(out, t)
+	}
+	return out
+}

--- a/utils/fill_test.go
+++ b/utils/fill_test.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type FillTestCase struct {
+	Num int
+}
+
+var fillTestCases = []FillTestCase{
+	{
+		Num: 1,
+	},
+	{
+		Num: 666,
+	},
+	{
+		Num: 10000,
+	},
+}
+
+func TestFill(t *testing.T) {
+	for _, fillTestCases := range fillTestCases {
+		arr := Fill(1, fillTestCases.Num)
+		require.Equal(t, fillTestCases.Num, len(arr))
+		for _, elem := range arr {
+			require.Equal(t, 1, elem)
+		}
+	}
+}

--- a/utils/filter.go
+++ b/utils/filter.go
@@ -1,0 +1,10 @@
+package utils
+
+func Filter[T any](arr []T, fn func(T) bool) (out []T) {
+	for _, elem := range arr {
+		if fn(elem) {
+			out = append(out, elem)
+		}
+	}
+	return out
+}

--- a/utils/flatMap.go
+++ b/utils/flatMap.go
@@ -1,0 +1,17 @@
+package utils
+
+import "context"
+
+func FlatMap[In, Out any](arr []In, fn func(In) []Out) (out []Out) {
+	for _, elem := range arr {
+		out = append(out, fn(elem)...)
+	}
+	return out
+}
+
+func FlatMapContext[In, Out any](ctx context.Context, arr []In, fn func(context.Context, In) []Out) (out []Out) {
+	for _, elem := range arr {
+		out = append(out, fn(ctx, elem)...)
+	}
+	return out
+}

--- a/utils/flatMap_test.go
+++ b/utils/flatMap_test.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type FlatMapTestCase struct {
+	In  []string
+	Out []string
+	Fn  func(s string) []string
+}
+
+var testCases = []FlatMapTestCase{
+	{
+		In:  []string{"abcd"},
+		Out: []string{"a", "b", "c", "d"},
+		Fn:  splitString,
+	},
+	{
+		In:  []string{"abcd", "efg"},
+		Out: []string{"a", "b", "c", "d", "e", "f", "g"},
+		Fn:  splitString,
+	},
+}
+
+func TestFlatMap(t *testing.T) {
+	for _, testCase := range testCases {
+		out := FlatMap(testCase.In, testCase.Fn)
+		require.Equal(t, testCase.Out, out)
+	}
+}
+
+func splitString(s string) []string {
+	return strings.Split(s, "")
+}

--- a/utils/forEach.go
+++ b/utils/forEach.go
@@ -1,0 +1,25 @@
+package utils
+
+import "context"
+
+func ForEach[T any](arr []T, fn func(T)) {
+	for _, elem := range arr {
+		fn(elem)
+	}
+}
+
+func ForEachContext[T any](ctx context.Context, arr []T, fn func(context.Context, T)) {
+	for _, elem := range arr {
+		fn(ctx, elem)
+	}
+}
+
+func ForEachContextError[T any](ctx context.Context, arr []T, fn func(context.Context, T) error) error {
+	for _, elem := range arr {
+		err := fn(ctx, elem)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/utils/getField.go
+++ b/utils/getField.go
@@ -1,0 +1,11 @@
+package utils
+
+import "reflect"
+
+func GetStringField[T any](t T, prop string) string {
+	value := reflect.Indirect(reflect.ValueOf(t))
+	if value.Kind() != reflect.Struct {
+		return ""
+	}
+	return value.FieldByName(prop).String()
+}

--- a/utils/getField_test.go
+++ b/utils/getField_test.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type GetStringFieldTestCase struct {
+	i             interface{}
+	prop          string
+	expectedValue string
+}
+
+type StructWithId struct {
+	Id string
+}
+
+var getStringFieldTestCases = []GetStringFieldTestCase{
+	{
+		i: StructWithId{
+			Id: "123",
+		},
+		prop:          "Id",
+		expectedValue: "123",
+	},
+	{
+		i: &StructWithId{
+			Id: "123",
+		},
+		prop:          "Id",
+		expectedValue: "123",
+	},
+	{
+		i:             234,
+		prop:          "Id",
+		expectedValue: "",
+	},
+	{
+		i:             nil,
+		prop:          "Id",
+		expectedValue: "",
+	},
+	{
+		i:             make(chan string),
+		prop:          "Id",
+		expectedValue: "",
+	},
+}
+
+func TestGetStringField(t *testing.T) {
+	for _, testCase := range getStringFieldTestCases {
+		actualValue := GetStringField(testCase.i, testCase.prop)
+		require.Equal(t, testCase.expectedValue, actualValue)
+	}
+}

--- a/utils/keyByField.go
+++ b/utils/keyByField.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+// KeyByField takes an array of structs and the field name,
+// and returns a map keyed by the value of each item's fieldName.
+// Note that a non-string-valued fieldName will cause errors.
+func KeyByField[T any](items []T, fieldName string) (map[string]T, error) {
+	keyed := make(map[string]T, len(items))
+	for _, item := range items {
+		key := GetStringField(item, fieldName)
+		if strings.HasPrefix(key, "<") && strings.HasSuffix(key, "Value>") {
+			// the key is not a string and thus will come back like <int value>
+			return nil, fmt.Errorf("the field to key by is not a string")
+		}
+		keyed[key] = item
+	}
+	return keyed, nil
+}

--- a/utils/keyByField_test.go
+++ b/utils/keyByField_test.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyByField(t *testing.T) {
+	type TestExample struct {
+		Id   string
+		Name string
+		Int  int
+	}
+	first := TestExample{Id: "one", Name: "first", Int: 1}
+	second := TestExample{Id: "two", Name: "second", Int: 2}
+	third := TestExample{Id: "three", Name: "third", Int: 3}
+
+	items := []TestExample{first, second, third}
+
+	result, err := KeyByField(items, "Id")
+	require.NoError(t, err)
+	expected := map[string]TestExample{
+		"one":   first,
+		"two":   second,
+		"three": third,
+	}
+	require.Equal(t, expected, result)
+
+	result, err = KeyByField(items, "Name")
+	require.NoError(t, err)
+	expected = map[string]TestExample{
+		"first":  first,
+		"second": second,
+		"third":  third,
+	}
+	require.Equal(t, expected, result)
+
+	result, err = KeyByField(items, "Int")
+	require.Error(t, err)
+	require.Nil(t, result)
+}

--- a/utils/map.go
+++ b/utils/map.go
@@ -1,0 +1,98 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+func Map[In, Out any](arr []In, fn func(In) Out) []Out {
+	out := make([]Out, 0, len(arr))
+	for _, elem := range arr {
+		out = append(out, fn(elem))
+	}
+	return out
+}
+
+// MapToValues returns an array of just the values of the input Map.
+func MapToValues[In any, Key comparable](arr map[Key]In) []In {
+	out := make([]In, 0, len(arr))
+	for _, elem := range arr {
+		out = append(out, elem)
+	}
+	return out
+}
+
+func MapToSlice[M ~map[K]V, K comparable, V, R any](items M, f func(K, V) R) []R {
+	out := make([]R, 0, len(items))
+	for k, v := range items {
+		out = append(out, f(k, v))
+	}
+	return out
+}
+
+func MapError[In, Out any](arr []In, fn func(In, int) (Out, error)) ([]Out, error) {
+	out := make([]Out, 0, len(arr))
+	for i, elem := range arr {
+		mapped, err := fn(elem, i)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mapped)
+	}
+
+	return out, nil
+}
+
+func MapContextError[In, Out any](
+	ctx context.Context,
+	arr []In,
+	fn func(context.Context, In, int) (Out, error),
+) ([]Out, error) {
+	out := make([]Out, 0, len(arr))
+	for i, elem := range arr {
+		mapped, err := fn(ctx, elem, i)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mapped)
+	}
+
+	return out, nil
+}
+
+type MapConcurrentFunction[T1, T2 any] func(ctx context.Context, t1 T1, i int) (T2, error)
+
+func MapConcurrent[T1, T2 any](ctx context.Context, t1s []T1, fn MapConcurrentFunction[T1, T2]) Results[T2] {
+	results := make(Results[T2], len(t1s))
+	var wg sync.WaitGroup
+
+	for i, t := range t1s {
+		wg.Add(1)
+		go func(ctx context.Context, t1 T1, i int) {
+			defer wg.Done()
+			defer func() {
+				r := recover()
+				if r != nil {
+					var defaultT2 T2
+					results[i] = Result[T2]{
+						Value: defaultT2,
+						Error: fmt.Errorf("MapConcurrent recovered from panic while processing value at index %d: %v", i, r),
+					}
+				}
+			}()
+
+			t2, err := fn(ctx, t1, i)
+
+			// this should be threadsafe since each goroutine only gets
+			// one index and we never resize
+			results[i] = Result[T2]{
+				Value: t2,
+				Error: err,
+			}
+		}(ctx, t, i)
+	}
+	wg.Wait()
+
+	return results
+}

--- a/utils/mapToField.go
+++ b/utils/mapToField.go
@@ -1,0 +1,9 @@
+package utils
+
+func MapToStringField[T any](tt []T, prop string) []string {
+	out := make([]string, 0, len(tt))
+	for _, elem := range tt {
+		out = append(out, GetStringField(elem, prop))
+	}
+	return out
+}

--- a/utils/mapToField_test.go
+++ b/utils/mapToField_test.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapToField(t *testing.T) {
+	arr := []StructWithId{
+		{
+			Id: "1",
+		},
+		{
+			Id: "2",
+		},
+		{
+			Id: "3",
+		},
+	}
+
+	ids := MapToStringField(arr, "Id")
+	require.Equal(t, []string{"1", "2", "3"}, ids)
+}
+
+func TestMapToFieldWithOutStructs(t *testing.T) {
+	arr := []int{1, 2, 3}
+
+	ids := MapToStringField(arr, "Id")
+	require.Equal(t, []string{"", "", ""}, ids)
+}

--- a/utils/map_test.go
+++ b/utils/map_test.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapConcurrent_simple(t *testing.T) {
+	fn := func(ctx context.Context, val int, _ int) (string, error) {
+		return strconv.Itoa(val), nil
+	}
+
+	results := MapConcurrent(context.Background(), []int{1, 2, 3}, fn)
+
+	require.Equal(t, 0, len(results.Errors()))
+	require.Equal(t, []string{"1", "2", "3"}, results.Values())
+}
+
+func TestMapConcurrent_error(t *testing.T) {
+	fn := func(ctx context.Context, val int, _ int) (string, error) {
+		if val == 2 {
+			return "", errors.New("I can't even")
+		}
+		return strconv.Itoa(val), nil
+	}
+
+	results := MapConcurrent(context.Background(), []int{1, 2, 3}, fn)
+
+	require.Equal(t, 1, len(results.Errors()))
+	require.ErrorContains(t, results.Errors()[0], "I can't even")
+	require.Equal(t, []string{"1", "3"}, results.Values())
+}
+
+func TestMapConcurrent_panic(t *testing.T) {
+	fn := func(ctx context.Context, val int, _ int) (string, error) {
+		if val == 2 {
+			panic("I can't even")
+		}
+		return strconv.Itoa(val), nil
+	}
+
+	results := MapConcurrent(context.Background(), []int{1, 2, 3}, fn)
+
+	require.Equal(t, 1, len(results.Errors()))
+	require.ErrorContains(t, results.Errors()[0], "MapConcurrent recovered from panic while processing value at index 1: I can't even") //nolint:lll
+	require.Equal(t, []string{"1", "3"}, results.Values())
+}

--- a/utils/notDefaultValue.go
+++ b/utils/notDefaultValue.go
@@ -1,0 +1,6 @@
+package utils
+
+func NotDefaultValue[T comparable](t T) bool {
+	var defaultValue T
+	return t != defaultValue
+}

--- a/utils/reduce.go
+++ b/utils/reduce.go
@@ -1,0 +1,30 @@
+package utils
+
+import "context"
+
+func Reduce[T, Acc any](
+	arr []T,
+	fn func(acc Acc, elem T, index int) Acc,
+	acc Acc,
+) Acc {
+	for i, elem := range arr {
+		acc = fn(acc, elem, i)
+	}
+	return acc
+}
+
+func ReduceContextError[T, Acc any](
+	ctx context.Context,
+	arr []T,
+	fn func(ctx context.Context, acc Acc, elem T, index int) (Acc, error),
+	acc Acc,
+) (Acc, error) {
+	var err error
+	for i, elem := range arr {
+		acc, err = fn(ctx, acc, elem, i)
+		if err != nil {
+			return acc, err
+		}
+	}
+	return acc, nil
+}

--- a/utils/result.go
+++ b/utils/result.go
@@ -1,0 +1,39 @@
+package utils
+
+import (
+	"errors"
+	"strings"
+)
+
+type Result[T any] struct {
+	Value T
+	Error error
+}
+
+type Results[T any] []Result[T]
+
+func (o *Results[T]) Values() (values []T) {
+	for _, result := range *o {
+		if result.Error == nil {
+			values = append(values, result.Value)
+		}
+	}
+	return values
+}
+
+func (o *Results[T]) Errors() (errors []error) {
+	for _, result := range *o {
+		if result.Error != nil {
+			errors = append(errors, result.Error)
+		}
+	}
+	return errors
+}
+
+func (o *Results[T]) Error() error {
+	errs := o.Errors()
+	if len(errs) > 0 {
+		return errors.New(strings.Join(ErrorStrings(errs), ", "))
+	}
+	return nil
+}

--- a/utils/timeValidator.go
+++ b/utils/timeValidator.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"errors"
+	"time"
+)
+
+type TimeRequiredValidator struct{}
+
+func (o *TimeRequiredValidator) Validate(value interface{}) error {
+	t, ok := value.(time.Time)
+	if !ok {
+		return errors.New("value is not a Time")
+	}
+	if t.IsZero() {
+		return errors.New("cannot be blank")
+	}
+	return nil
+}
+
+func TimeRequired() *TimeRequiredValidator {
+	return &TimeRequiredValidator{}
+}


### PR DESCRIPTION
- Copy over the utils from the observability monitoring api project along with existing tests
- These could be moved to the top-level if we don't want the `utils` package namespace?