### PR TITLE
Added Unit Tests for ForEach

### DIFF
--- a/utils/for_each.go
+++ b/utils/for_each.go
@@ -1,6 +1,8 @@
 package utils
 
-import "context"
+import (
+	"context"
+)
 
 func ForEach[T any](arr []T, fn func(T)) {
 	for _, elem := range arr {

--- a/utils/for_each_test.go
+++ b/utils/for_each_test.go
@@ -1,0 +1,57 @@
+package utils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type forEachTestCase struct {
+	In  []string
+	Out []string
+}
+
+var forEachTestCases = []forEachTestCase{
+	{
+		In:  []string{"aaa", "bbb"},
+		Out: []string{"aaa", "bbb"},
+	},
+	{
+		In:  []string{"this", "that"},
+		Out: []string{"this", "that"},
+	},
+}
+
+func TestForEach(t *testing.T) {
+	for _, testCase := range forEachTestCases {
+		// foreach does not return a value, so we need to test
+		// that the receiver function gets called by pushing each value to an array.
+		var stringSlice = []string{}
+		fn := func(s string) {
+			stringSlice = append(stringSlice, s)
+		}
+
+		ForEach(testCase.In, fn)
+		require.Equal(t, testCase.Out, stringSlice)
+	}
+}
+
+func TestForEachContext(t *testing.T) {
+	type contextKey string
+	var key = contextKey("key")
+
+	for _, testCase := range forEachTestCases {
+		// foreach does not return a value, so we need to test
+		// that the receiver function gets called by pushing each value to an array.
+		var stringSlice = []string{}
+		fn := func(c context.Context, s string) {
+			require.Equal(t, "a_value", c.Value(key))
+			stringSlice = append(stringSlice, s)
+		}
+		ctx := context.WithValue(context.Background(), key, "a_value")
+
+		ForEachContext(ctx, testCase.In, fn)
+		require.Equal(t, testCase.Out, stringSlice)
+	}
+}


### PR DESCRIPTION
This PR adds a Unit test for the `ForEach` generic function.

To tophat:
- Run `go test -v utils/forEach.go utils/forEach_test.go` to test only the `ForEach`.
- Run `go test -v` to run the whole test suite.

What to look for:
- Hoping for suggestions on how I can refactor the test suite to reduce code duplication. I think there is potential to use generics inside the tests as well.