### PR TITLE
Use a forked version that fixes an error in the original action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -52,7 +52,7 @@ jobs:
       if: github.ref == 'refs/heads/main'
       run: cp coverage.lcov main.lcov
     - name: Code Coverage Report
-      uses: romeovs/lcov-reporter-action@v0.3.1
+      uses: osmind-development-org/lcov-reporter-action@v0.3.2
       if: matrix.version == '1.18.1'
       with:
         lcov-file: ./coverage.lcov


### PR DESCRIPTION
Original issue reported on Dec 3, 2021, no fix available yet:
https://github.com/romeovs/lcov-reporter-action/issues/33

Fixed in this fork PR: https://github.com/osmind-development-org/lcov-reporter-action/pull/1

And released: https://github.com/osmind-development-org/lcov-reporter-action/releases/tag/v0.3.2