### PR TITLE
Move all utils into the project root, `main` namespace.

### DIFF
--- a/chunk.go
+++ b/chunk.go
@@ -1,4 +1,4 @@
-package main
+package hoff
 
 // Chunk takes an input array of T elements, and "chunks" into groups of chunkSize elements.
 // If the input array is empty, or the batchSize is 0, return an empty slice of slices.

--- a/chunk.go
+++ b/chunk.go
@@ -1,4 +1,4 @@
-package utils
+package main
 
 // Chunk takes an input array of T elements, and "chunks" into groups of chunkSize elements.
 // If the input array is empty, or the batchSize is 0, return an empty slice of slices.

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -1,4 +1,4 @@
-package utils
+package main
 
 import (
 	"testing"

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -1,4 +1,4 @@
-package main
+package hoff
 
 import (
 	"testing"

--- a/common.go
+++ b/common.go
@@ -1,0 +1,3 @@
+package main
+
+type contextKey string

--- a/common.go
+++ b/common.go
@@ -1,3 +1,3 @@
-package main
+package hoff
 
 type contextKey string

--- a/example/main.go
+++ b/example/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/Shopify/hoff"
+)
+
+func main() {
+	filtered := hoff.Filter([]int{1, 2, 3}, func(i int) bool { return i < 3 })
+	fmt.Println(filtered)
+}

--- a/fill.go
+++ b/fill.go
@@ -1,4 +1,4 @@
-package utils
+package main
 
 func Fill[T any](t T, num int) []T {
 	out := make([]T, 0, num)

--- a/fill.go
+++ b/fill.go
@@ -1,4 +1,4 @@
-package main
+package hoff
 
 func Fill[T any](t T, num int) []T {
 	out := make([]T, 0, num)

--- a/fill_test.go
+++ b/fill_test.go
@@ -1,4 +1,4 @@
-package utils
+package main
 
 import (
 	"testing"

--- a/fill_test.go
+++ b/fill_test.go
@@ -1,4 +1,4 @@
-package main
+package hoff
 
 import (
 	"testing"

--- a/filter.go
+++ b/filter.go
@@ -1,4 +1,4 @@
-package utils
+package main
 
 import "context"
 

--- a/filter.go
+++ b/filter.go
@@ -1,4 +1,4 @@
-package main
+package hoff
 
 import "context"
 

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,4 +1,4 @@
-package utils
+package main
 
 import (
 	"context"

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,4 +1,4 @@
-package main
+package hoff
 
 import (
 	"context"

--- a/flatmap.go
+++ b/flatmap.go
@@ -1,4 +1,4 @@
-package main
+package hoff
 
 import "context"
 

--- a/flatmap.go
+++ b/flatmap.go
@@ -1,9 +1,9 @@
-package utils
+package main
 
 import "context"
 
 // FlatMap applies a transformation to an array of elements and
-// returns another array with the transformed result
+// returns another array with the transformed result.
 func FlatMap[In, Out any](arr []In, fn func(In) []Out) (out []Out) {
 	for _, elem := range arr {
 		out = append(out, fn(elem)...)
@@ -11,9 +11,9 @@ func FlatMap[In, Out any](arr []In, fn func(In) []Out) (out []Out) {
 	return out
 }
 
-// FlatMap applies a transformation to an array of elements and
+// FlatMapError applies a transformation to an array of elements and
 // returns another array with the transformed result. If one of the
-// transformations fails, it will return early
+// transformations fails, it will return early.
 func FlatMapError[In, Out any](arr []In, fn func(In) ([]Out, error)) (out []Out, err error) {
 	for _, elem := range arr {
 		tr, err := fn(elem)
@@ -34,9 +34,9 @@ func FlatMapContext[In, Out any](ctx context.Context, arr []In, fn func(context.
 	return out
 }
 
-// FlatMapContext applies the FlatMap transformation while, at the same time,
+// FlatMapContextError applies the FlatMap transformation while, at the same time,
 // shares a context with the transforming function. If one of the
-// transformations fails, it will return early
+// transformations fails, it will return early.
 func FlatMapContextError[In, Out any](ctx context.Context, arr []In, fn func(context.Context, In) ([]Out, error)) (out []Out, err error) {
 	for _, elem := range arr {
 		tr, err := fn(ctx, elem)

--- a/flatmap_test.go
+++ b/flatmap_test.go
@@ -1,4 +1,4 @@
-package utils
+package main
 
 import (
 	"context"
@@ -24,8 +24,6 @@ var testCases = []flatMapTestCase{
 		out: []string{"a", "b", "c", "d", "e", "f", "g"},
 	},
 }
-
-type contextKey string
 
 var key = contextKey("key")
 
@@ -70,7 +68,7 @@ func TestFlatMapErrorFails(t *testing.T) {
 func ExampleFlatMapError() {
 	properPrefixes := func(s string) ([]string, error) {
 		if len(s) < 2 {
-			return nil, fmt.Errorf("String '%s' has no proper prefixes", s)
+			return nil, fmt.Errorf("string '%s' has no proper prefixes", s)
 		}
 
 		res := make([]string, len(s)-1)
@@ -88,7 +86,7 @@ func ExampleFlatMapError() {
 	fmt.Println(err)
 	// Output:
 	// [a ab abc e ef]
-	// String 'x' has no proper prefixes
+	// string 'x' has no proper prefixes
 }
 
 func BenchmarkFlatMapError(b *testing.B) {
@@ -139,18 +137,18 @@ func splitString(s string) []string {
 
 func splitStringWithError(s string) ([]string, error) {
 	if len(s) < 4 {
-		return nil, fmt.Errorf("String '%s' too short", s)
+		return nil, fmt.Errorf("string '%s' too short", s)
 	}
 	return strings.Split(s, ""), nil
 }
 
 func splitStringWithContextAndError(ctx context.Context, s string) ([]string, error) {
 	if ctx.Value(key) != "a_value" {
-		return nil, fmt.Errorf("Context values not received")
+		return nil, fmt.Errorf("context values not received")
 	}
 
 	if len(s) < 4 {
-		return nil, fmt.Errorf("String '%s' too short", s)
+		return nil, fmt.Errorf("string '%s' too short", s)
 	}
 	return strings.Split(s, ""), nil
 }

--- a/flatmap_test.go
+++ b/flatmap_test.go
@@ -1,4 +1,4 @@
-package main
+package hoff
 
 import (
 	"context"

--- a/for_each.go
+++ b/for_each.go
@@ -1,4 +1,4 @@
-package utils
+package main
 
 import (
 	"context"

--- a/for_each.go
+++ b/for_each.go
@@ -1,4 +1,4 @@
-package main
+package hoff
 
 import (
 	"context"

--- a/for_each_test.go
+++ b/for_each_test.go
@@ -1,4 +1,4 @@
-package main
+package hoff
 
 import (
 	"context"

--- a/for_each_test.go
+++ b/for_each_test.go
@@ -1,4 +1,4 @@
-package utils
+package main
 
 import (
 	"context"
@@ -27,7 +27,7 @@ func TestForEach(t *testing.T) {
 	for _, testCase := range forEachTestCases {
 		// foreach does not return a value, so we need to test
 		// that the receiver function gets called by pushing each value to an array.
-		var stringSlice = []string{}
+		var stringSlice = make([]string, 0, len(testCase.In))
 		fn := func(s string) {
 			stringSlice = append(stringSlice, s)
 		}
@@ -44,7 +44,7 @@ func TestForEachContext(t *testing.T) {
 	for _, testCase := range forEachTestCases {
 		// foreach does not return a value, so we need to test
 		// that the receiver function gets called by pushing each value to an array.
-		var stringSlice = []string{}
+		var stringSlice = make([]string, 0, len(testCase.In))
 		fn := func(c context.Context, s string) {
 			require.Equal(t, "a_value", c.Value(key))
 			stringSlice = append(stringSlice, s)

--- a/map.go
+++ b/map.go
@@ -1,4 +1,4 @@
-package main
+package hoff
 
 import (
 	"context"
@@ -66,7 +66,10 @@ func MapConcurrentToResults[In, Out any](
 					var val Out
 					results[i] = Result[Out]{
 						Value: val,
-						Error: fmt.Errorf("MapConcurrentToResults recovered from panic while processing index %d, value %v: %v", i, elem, r),
+						Error: fmt.Errorf(
+							"MapConcurrentToResults recovered from panic while processing index %d, value %v: %v", i,
+							elem, r,
+						),
 					}
 				}
 			}()
@@ -100,7 +103,9 @@ func MapConcurrentError[In, Out any](
 			defer func() {
 				r := recover()
 				if r != nil && atomic.CompareAndSwapUint32(&shutdown, 0, 1) {
-					errs <- fmt.Errorf("MapConcurrentError recovered from panic while processing index %d, value %v: %v", i, elem, r)
+					errs <- fmt.Errorf(
+						"MapConcurrentError recovered from panic while processing index %d, value %v: %v", i, elem, r,
+					)
 				}
 			}()
 

--- a/map_test.go
+++ b/map_test.go
@@ -1,4 +1,4 @@
-package main
+package hoff
 
 import (
 	"context"

--- a/map_test.go
+++ b/map_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type contextKey string
-
 const (
 	ctxKey               = contextKey("answer")
 	benchmarkArrayLength = 10_000
@@ -38,17 +36,21 @@ func TestMapError(t *testing.T) {
 		return n, nil
 	}
 
-	t.Run("success", func(t *testing.T) {
-		results, err := MapError([]int{1, 2, 3}, fn)
-		require.NoError(t, err)
-		require.Equal(t, []int{1, 2, 3}, results)
-	})
+	t.Run(
+		"success", func(t *testing.T) {
+			results, err := MapError([]int{1, 2, 3}, fn)
+			require.NoError(t, err)
+			require.Equal(t, []int{1, 2, 3}, results)
+		},
+	)
 
-	t.Run("failure", func(t *testing.T) {
-		results, err := MapError([]int{2, 3, 4}, fn)
-		require.Error(t, err)
-		require.Nil(t, results)
-	})
+	t.Run(
+		"failure", func(t *testing.T) {
+			results, err := MapError([]int{2, 3, 4}, fn)
+			require.Error(t, err)
+			require.Nil(t, results)
+		},
+	)
 }
 
 func TestMapContextError(t *testing.T) {
@@ -60,114 +62,130 @@ func TestMapContextError(t *testing.T) {
 		return n, nil
 	}
 
-	t.Run("success", func(t *testing.T) {
-		results, err := MapContextError(ctx, []int{1, 2, 3}, fn)
-		require.NoError(t, err)
-		require.Equal(t, results, []int{1, 2, 3})
-	})
+	t.Run(
+		"success", func(t *testing.T) {
+			results, err := MapContextError(ctx, []int{1, 2, 3}, fn)
+			require.NoError(t, err)
+			require.Equal(t, results, []int{1, 2, 3})
+		},
+	)
 
-	t.Run("failure", func(t *testing.T) {
-		results, err := MapContextError(ctx, []int{1, 2, 42}, fn)
-		require.Error(t, err)
-		require.Nil(t, results)
-	})
+	t.Run(
+		"failure", func(t *testing.T) {
+			results, err := MapContextError(ctx, []int{1, 2, 42}, fn)
+			require.Error(t, err)
+			require.Nil(t, results)
+		},
+	)
 }
 
 func TestMapConcurrentToResults(t *testing.T) {
 	err := errors.New("I can't even")
 
-	t.Run("success", func(t *testing.T) {
-		fn := func(ctx context.Context, val int) (string, error) {
-			return strconv.Itoa(val), nil
-		}
-		results := MapConcurrentToResults(context.Background(), []int{1, 2, 3}, fn)
-
-		expected := Results[string]{
-			{"1", nil},
-			{"2", nil},
-			{"3", nil},
-		}
-		require.Equal(t, expected, results)
-	})
-
-	t.Run("failure", func(t *testing.T) {
-		fn := func(ctx context.Context, val int) (string, error) {
-			if val == 2 {
-				return "", err
+	t.Run(
+		"success", func(t *testing.T) {
+			fn := func(ctx context.Context, val int) (string, error) {
+				return strconv.Itoa(val), nil
 			}
-			return strconv.Itoa(val), nil
-		}
+			results := MapConcurrentToResults(context.Background(), []int{1, 2, 3}, fn)
 
-		results := MapConcurrentToResults(context.Background(), []int{1, 2, 3}, fn)
-
-		expected := Results[string]{
-			{"1", nil},
-			{"", fmt.Errorf("MapConcurrentToResults got an error in index 1, value 2: %w", err)},
-			{"3", nil},
-		}
-		require.Equal(t, expected, results)
-	})
-
-	t.Run("panic", func(t *testing.T) {
-		fn := func(ctx context.Context, val int) (string, error) {
-			if val == 2 {
-				return "", err
+			expected := Results[string]{
+				{"1", nil},
+				{"2", nil},
+				{"3", nil},
 			}
-			return strconv.Itoa(val), nil
-		}
+			require.Equal(t, expected, results)
+		},
+	)
 
-		results := MapConcurrentToResults(context.Background(), []int{1, 2, 3}, fn)
+	t.Run(
+		"failure", func(t *testing.T) {
+			fn := func(ctx context.Context, val int) (string, error) {
+				if val == 2 {
+					return "", err
+				}
+				return strconv.Itoa(val), nil
+			}
 
-		expected := Results[string]{
-			{"1", nil},
-			{"", fmt.Errorf("MapConcurrentToResults got an error in index 1, value 2: %w", err)},
-			{"3", nil},
-		}
-		require.Equal(t, expected, results)
-	})
+			results := MapConcurrentToResults(context.Background(), []int{1, 2, 3}, fn)
+
+			expected := Results[string]{
+				{"1", nil},
+				{"", fmt.Errorf("MapConcurrentToResults got an error in index 1, value 2: %w", err)},
+				{"3", nil},
+			}
+			require.Equal(t, expected, results)
+		},
+	)
+
+	t.Run(
+		"panic", func(t *testing.T) {
+			fn := func(ctx context.Context, val int) (string, error) {
+				if val == 2 {
+					return "", err
+				}
+				return strconv.Itoa(val), nil
+			}
+
+			results := MapConcurrentToResults(context.Background(), []int{1, 2, 3}, fn)
+
+			expected := Results[string]{
+				{"1", nil},
+				{"", fmt.Errorf("MapConcurrentToResults got an error in index 1, value 2: %w", err)},
+				{"3", nil},
+			}
+			require.Equal(t, expected, results)
+		},
+	)
 }
 
 func TestMapConcurrentError(t *testing.T) {
 	err := errors.New("I can't even")
 
-	t.Run("success", func(t *testing.T) {
-		fn := func(ctx context.Context, val int) (string, error) {
-			return strconv.Itoa(val), nil
-		}
-		results, err := MapConcurrentError(context.Background(), []int{1, 2, 3}, fn)
-
-		require.Equal(t, []string{"1", "2", "3"}, results)
-		require.Nil(t, err)
-	})
-
-	t.Run("failure", func(t *testing.T) {
-		fn := func(ctx context.Context, val int) (string, error) {
-			if val == 2 {
-				return "", err
+	t.Run(
+		"success", func(t *testing.T) {
+			fn := func(ctx context.Context, val int) (string, error) {
+				return strconv.Itoa(val), nil
 			}
-			return strconv.Itoa(val), nil
-		}
+			results, err := MapConcurrentError(context.Background(), []int{1, 2, 3}, fn)
 
-		results, err := MapConcurrentError(context.Background(), []int{1, 2, 3}, fn)
+			require.Equal(t, []string{"1", "2", "3"}, results)
+			require.Nil(t, err)
+		},
+	)
 
-		require.Error(t, err)
-		require.Nil(t, results)
-	})
-
-	t.Run("panic", func(t *testing.T) {
-		err := errors.New("I can't even")
-		fn := func(ctx context.Context, val int) (string, error) {
-			if val == 2 {
-				return "", err
+	t.Run(
+		"failure", func(t *testing.T) {
+			fn := func(ctx context.Context, val int) (string, error) {
+				if val == 2 {
+					return "", err
+				}
+				return strconv.Itoa(val), nil
 			}
-			return strconv.Itoa(val), nil
-		}
 
-		results, err := MapConcurrentError(context.Background(), []int{1, 2, 3}, fn)
+			results, err := MapConcurrentError(context.Background(), []int{1, 2, 3}, fn)
 
-		require.Error(t, err)
-		require.Nil(t, results)
-	})
+			require.Error(t, err)
+			require.Nil(t, results)
+		},
+	)
+
+	t.Run(
+		"panic", func(t *testing.T) {
+			err := errors.New("I can't even")
+			fn := func(ctx context.Context, val int) (string, error) {
+				if val == 2 {
+					return "", err
+				}
+				return strconv.Itoa(val), nil
+			}
+
+			results, err := MapConcurrentError(context.Background(), []int{1, 2, 3}, fn)
+
+			require.Error(t, err)
+			require.Nil(t, results)
+		},
+	)
 }
 
 func BenchmarkMap(b *testing.B) {

--- a/pluck.go
+++ b/pluck.go
@@ -1,4 +1,4 @@
-package main
+package hoff
 
 // Pluck takes an input array of maps with K keys and V values and "Plucks" the selected keys into an array of arrays of V values.
 // If the input array is empty, or the keys is 0, return an empty slice of slices.

--- a/pluck.go
+++ b/pluck.go
@@ -1,4 +1,4 @@
-package utils
+package main
 
 // Pluck takes an input array of maps with K keys and V values and "Plucks" the selected keys into an array of arrays of V values.
 // If the input array is empty, or the keys is 0, return an empty slice of slices.

--- a/pluck_test.go
+++ b/pluck_test.go
@@ -1,4 +1,4 @@
-package main
+package hoff
 
 import (
 	"fmt"

--- a/pluck_test.go
+++ b/pluck_test.go
@@ -1,4 +1,4 @@
-package utils
+package main
 
 import (
 	"fmt"
@@ -13,25 +13,31 @@ func ExamplePluck() {
 }
 
 func TestPluckStringBasic(t *testing.T) {
-	output := Pluck([]map[string]any{
-		{"foo": 1, "bar": 2, "shop": 3},
-		{"foo": 4, "bar": 5, "shop": 6},
-	}, "foo", "bar")
+	output := Pluck(
+		[]map[string]any{
+			{"foo": 1, "bar": 2, "shop": 3},
+			{"foo": 4, "bar": 5, "shop": 6},
+		}, "foo", "bar",
+	)
 	require.Equal(t, [][]any{{1, 2}, {4, 5}}, output, "2 keys extracted")
 }
 
 func TestPluckStringNil(t *testing.T) {
-	output := Pluck([]map[string]any{
-		{"foo": 1, "bar": 2, "shop": 3},
-		{"foo": 4, "bar": 5},
-	}, "foo", "shop")
+	output := Pluck(
+		[]map[string]any{
+			{"foo": 1, "bar": 2, "shop": 3},
+			{"foo": 4, "bar": 5},
+		}, "foo", "shop",
+	)
 	require.Equal(t, [][]any{{1, 3}, {4, nil}}, output, "2 keys extracted with nil value")
 }
 
 func TestPluckStringSingleKey(t *testing.T) {
-	output := Pluck([]map[string]any{
-		{"foo": 1, "bar": 2, "shop": 3},
-		{"foo": 4, "bar": 5},
-	}, "foo")
+	output := Pluck(
+		[]map[string]any{
+			{"foo": 1, "bar": 2, "shop": 3},
+			{"foo": 4, "bar": 5},
+		}, "foo",
+	)
 	require.Equal(t, [][]any{{1}, {4}}, output, "1 keys extracted")
 }

--- a/reduce.go
+++ b/reduce.go
@@ -1,4 +1,4 @@
-package utils
+package main
 
 import "context"
 

--- a/reduce.go
+++ b/reduce.go
@@ -1,4 +1,4 @@
-package main
+package hoff
 
 import "context"
 

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -1,4 +1,4 @@
-package utils
+package main
 
 import (
 	"context"

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -1,4 +1,4 @@
-package main
+package hoff
 
 import (
 	"context"

--- a/result.go
+++ b/result.go
@@ -1,4 +1,4 @@
-package main
+package hoff
 
 // Result holds a result of a concurrent operation.
 type Result[T any] struct {

--- a/result_test.go
+++ b/result_test.go
@@ -1,4 +1,4 @@
-package main
+package hoff
 
 import (
 	"errors"
@@ -19,18 +19,24 @@ func TestResults(t *testing.T) {
 		{0, errors.New("fizz")},
 	}
 
-	t.Run("HasErrors", func(t *testing.T) {
-		require.False(t, ok.HasError())
-		require.True(t, err.HasError())
-	})
+	t.Run(
+		"HasErrors", func(t *testing.T) {
+			require.False(t, ok.HasError())
+			require.True(t, err.HasError())
+		},
+	)
 
-	t.Run("Errors", func(t *testing.T) {
-		require.Equal(t, []error{nil, nil, nil}, ok.Errors())
-		require.Equal(t, []error{nil, nil, errors.New("fizz")}, err.Errors())
-	})
+	t.Run(
+		"Errors", func(t *testing.T) {
+			require.Equal(t, []error{nil, nil, nil}, ok.Errors())
+			require.Equal(t, []error{nil, nil, errors.New("fizz")}, err.Errors())
+		},
+	)
 
-	t.Run("Values", func(t *testing.T) {
-		require.Equal(t, []int{1, 2, 3}, ok.Values())
-		require.Equal(t, []int{1, 2, 0}, err.Values())
-	})
+	t.Run(
+		"Values", func(t *testing.T) {
+			require.Equal(t, []int{1, 2, 3}, ok.Values())
+			require.Equal(t, []int{1, 2, 0}, err.Values())
+		},
+	)
 }


### PR DESCRIPTION
* Should be accessible as hoff.Filter etc in consumer packages
* add common.go and define contextKey there so it doesn't get redeclared
* update some of the docs for flatmap, make errors lowercased in tests
* use `make` to create string slices in for_each_test
* gofmt auto-formatting