### PR TITLE
Adds badge and link to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hoff: Higher Order Functions (and Friends)
+# hoff: Higher Order Functions (and Friends) [![Go Reference](https://pkg.go.dev/badge/github.com/Shopify/hoff.svg)](https://pkg.go.dev/github.com/Shopify/hoff)
 
 Golang 1.18+ implementations of common methods/data structures using Go Generics
 


### PR DESCRIPTION
Adds [Go's standard docs badge](https://pkg.go.dev/badge) linking to the official docs:

![image](https://user-images.githubusercontent.com/4732915/168119194-ea817dfd-4196-4b6f-8fdf-b1c8540c1db2.png)

Since we don't have more badges yet, I suggested to leave it in the title line — we can move to a deidcated line once we add more badges ; )