### PR TITLE
Refactor Result Values, Errors and add Error method

### DIFF
--- a/map_test.go
+++ b/map_test.go
@@ -348,7 +348,7 @@ func ExampleMapConcurrentToResults_failure() {
 	results := MapConcurrentToResults(ctx, []int{1, 2, 42}, fn)
 
 	fmt.Println(results.Errors())
-	// Output: [<nil> <nil> MapConcurrentToResults got an error in index 2, value 42: 42 is already the answer]
+	// Output: [MapConcurrentToResults got an error in index 2, value 42: 42 is already the answer]
 }
 
 func ExampleMapConcurrentToResults_panic() {
@@ -363,7 +363,7 @@ func ExampleMapConcurrentToResults_panic() {
 	results := MapConcurrentToResults(ctx, []int{1, 2, 42}, fn)
 
 	fmt.Println(results.Errors())
-	// Output: [<nil> <nil> MapConcurrentToResults recovered from panic while processing index 2, value 42: 42 is already the answer]
+	// Output: [MapConcurrentToResults recovered from panic while processing index 2, value 42: 42 is already the answer]
 }
 
 func ExampleMapConcurrentError_success() {

--- a/map_test.go
+++ b/map_test.go
@@ -236,7 +236,7 @@ func BenchmarkMapConcurrentToResults(b *testing.B) {
 		r = MapConcurrentToResults(ctx, arr, fn)
 	}
 	benchResult = r.Values()
-	benchErr = r.Errors()[0]
+	benchErr = nil
 }
 
 func BenchmarkMapConcurrentError(b *testing.B) {

--- a/result.go
+++ b/result.go
@@ -1,5 +1,10 @@
 package hoff
 
+import (
+	"errors"
+	"strings"
+)
+
 // Result holds a result of a concurrent operation.
 type Result[T any] struct {
 	Value T
@@ -19,8 +24,38 @@ func (rs Results[T]) HasError() bool {
 	return false
 }
 
-// Values returns an array with the values.
-func (rs Results[T]) Values() []T { return Map(rs, func(r Result[T]) T { return r.Value }) }
+// Values returns an array with the values of all non-error Results.
+func (rs Results[T]) Values() (values []T) {
+	for _, result := range rs {
+		if result.Error == nil {
+			values = append(values, result.Value)
+		}
+	}
+	return values
+}
 
-// Errors returns an array with the errors.
-func (rs Results[T]) Errors() []error { return Map(rs, func(r Result[T]) error { return r.Error }) }
+// Errors returns an array with the errors of all non-valid Results.
+func (rs Results[T]) Errors() (errors []error) {
+	for _, result := range rs {
+		if result.Error != nil {
+			errors = append(errors, result.Error)
+		}
+	}
+	return errors
+}
+
+// Error returns nil if the results contain no errors,
+// or an error with the message a comma-separated string of all the errors in the collection.
+func (rs Results[T]) Error() error {
+	errs := rs.Errors()
+	if len(errs) > 0 {
+		errorStrings := Map(
+			errs, func(err error) string {
+				return err.Error()
+			},
+		)
+
+		return errors.New(strings.Join(errorStrings, ", "))
+	}
+	return nil
+}

--- a/result_test.go
+++ b/result_test.go
@@ -2,10 +2,83 @@ package hoff
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func ExampleResults_HasError() {
+	errStrings := Results[int]{
+		{0, nil},
+		{1, errors.New("first")},
+		{2, errors.New("second")},
+	}
+	fmt.Println(errStrings.HasError())
+
+	noErrors := Results[int]{
+		{0, nil},
+		{1, nil},
+	}
+	fmt.Println(noErrors.HasError())
+	// Output:
+	// true
+	// false
+}
+
+func ExampleResults_Values() {
+	errStrings := Results[int]{
+		{0, nil},
+		{1, errors.New("first")},
+		{2, errors.New("second")},
+	}
+	fmt.Println(errStrings.Values())
+
+	noErrors := Results[int]{
+		{0, nil},
+		{1, nil},
+	}
+	fmt.Println(noErrors.Values())
+	// Output:
+	// [0]
+	// [0 1]
+}
+
+func ExampleResults_Errors() {
+	errStrings := Results[int]{
+		{0, nil},
+		{1, errors.New("first")},
+		{2, errors.New("second")},
+	}
+	fmt.Println(errStrings.Errors())
+
+	noErrors := Results[int]{
+		{0, nil},
+		{1, nil},
+	}
+	fmt.Println(noErrors.Errors())
+	// Output:
+	// [first second]
+	// []
+}
+
+func ExampleResults_Error() {
+	errStrings := Results[int]{
+		{0, nil},
+		{1, errors.New("first")},
+		{2, errors.New("second")},
+	}
+	fmt.Println(errStrings.Error().Error())
+
+	noErrors := Results[int]{
+		{0, nil},
+		{1, nil},
+	}
+	fmt.Println(noErrors.Error() == nil, noErrors.Error())
+	// Output:
+	// first, second
+	// true <nil>
+}
 
 func TestResults(t *testing.T) {
 	ok := Results[int]{
@@ -19,6 +92,12 @@ func TestResults(t *testing.T) {
 		{0, errors.New("fizz")},
 	}
 
+	errStrings := Results[int]{
+		{0, errors.New("zeroth")},
+		{1, errors.New("first")},
+		{2, errors.New("second")},
+	}
+
 	t.Run(
 		"HasErrors", func(t *testing.T) {
 			require.False(t, ok.HasError())
@@ -28,15 +107,23 @@ func TestResults(t *testing.T) {
 
 	t.Run(
 		"Errors", func(t *testing.T) {
-			require.Equal(t, []error{nil, nil, nil}, ok.Errors())
-			require.Equal(t, []error{nil, nil, errors.New("fizz")}, err.Errors())
+			require.Equal(t, []error(nil), ok.Errors())
+			require.Equal(t, []error{errors.New("fizz")}, err.Errors())
 		},
 	)
 
 	t.Run(
 		"Values", func(t *testing.T) {
 			require.Equal(t, []int{1, 2, 3}, ok.Values())
-			require.Equal(t, []int{1, 2, 0}, err.Values())
+			require.Equal(t, []int{1, 2}, err.Values())
+		},
+	)
+
+	t.Run(
+		"Error", func(t *testing.T) {
+			require.Nil(t, ok.Error())
+			require.Equal(t, errors.New("fizz"), err.Error())
+			require.Equal(t, errors.New("zeroth, first, second"), errStrings.Error())
 		},
 	)
 }


### PR DESCRIPTION
* add Error method that coalesces the Results error messages into one error with the messages joined, comma-separated
* update Values only return non-error result values, Errors to only include errors from Results with errors
* add Example tests, update existing to reflect new logic