### PR TITLE
Makes `Chunk`s examples to runnable

### DIFF
--- a/chunk.go
+++ b/chunk.go
@@ -3,10 +3,6 @@ package hoff
 // Chunk takes an input array of T elements, and "chunks" into groups of chunkSize elements.
 // If the input array is empty, or the batchSize is 0, return an empty slice of slices.
 // Adapted to generics from https://github.com/golang/go/wiki/SliceTricks#batching-with-minimal-allocation.
-// Examples:
-// Chunk([]int{1, 2, 3, 4, 5}, 2) = [[1, 2] [3, 4], [5]]
-// Chunk([]int{}, 2) = []
-// Chunk([]int{1, 2, 3}, 0) = [].
 func Chunk[T any](actions []T, batchSize int) [][]T {
 	// if the input is empty or batch size is 0, return an empty slice of slices
 	if len(actions) == 0 || batchSize < 1 {

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -1,6 +1,7 @@
 package hoff
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -113,4 +114,19 @@ func TestChunkStructs(t *testing.T) {
 		output := Chunk(testCase.Input, testCase.ChunkSize)
 		require.Equal(t, testCase.ExpectedOutput, output, testCase.Message)
 	}
+}
+
+func ExampleChunk() {
+	fmt.Println(Chunk([]int{1, 2, 3, 4, 5}, 2))
+	// Output: [[1 2] [3 4] [5]]
+}
+
+func ExampleChunk_withEmptyArray() {
+	fmt.Println(Chunk([]int{}, 2))
+	// Output: []
+}
+
+func ExampleChunk_zeroBatchSize() {
+	fmt.Println(Chunk([]int{1, 2, 3}, 0))
+	// Output: []
 }


### PR DESCRIPTION
I noticed there was a couple of pure text examples in [`Chunk`'s docs](https://pkg.go.dev/github.com/Shopify/hoff#Chunk):

![image](https://user-images.githubusercontent.com/4732915/191063634-176cefdb-a56b-4a32-a685-69f4ed44c079.png)

They are not well-formatted, making it difficult to follow. So I moved them to runnable examples, which looks better and are ran and tested automagically when we run `go test`:

![image](https://user-images.githubusercontent.com/4732915/191064051-1702d587-a8e9-4f3b-827f-ac449386d4d7.png)
