### PR TITLE
Update to minimum go version 1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
   deps:
     strategy:
       matrix:
-        version: ['1.18.0', '1.18.1']
+        version: ['1.22.0']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
     needs: ["deps"]
     strategy:
       matrix:
-        version: ['1.18.0', '1.18.1']
+        version: ['1.22.0']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -42,7 +42,7 @@ jobs:
     needs: ["deps"]
     strategy:
       matrix:
-        version: ['1.18.0', '1.18.1']
+        version: ['1.22.0']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -52,7 +52,7 @@ jobs:
         go-version: ${{ matrix.version }}
     - name: Main branch coverage
       uses: actions/cache@v3
-      if: matrix.version == '1.18.1'
+      if: matrix.version == '1.22.0'
       with:
         path: |
           main.lcov
@@ -61,14 +61,14 @@ jobs:
           ${{ runner.os }}-refs/heads/main-
     - name: Test
       run: go test -v -coverprofile coverage.out -race ./...
-    - uses: jandelgado/gcov2lcov-action@v1.0.5
-      if: matrix.version == '1.18.1'
+    - uses: jandelgado/gcov2lcov-action@v1.0.9
+      if: matrix.version == '1.22.0'
     - name: Store main branch lcov
-      if: github.ref == 'refs/heads/main' && matrix.version == '1.18.1'
+      if: github.ref == 'refs/heads/main' && matrix.version == '1.22.0'
       run: cp coverage.lcov main.lcov
     - name: Code Coverage Report
       uses: osmind-development-org/lcov-reporter-action@v0.3.2
-      if: matrix.version == '1.18.1' && github.event_name == 'pull_request'
+      if: matrix.version == '1.22.0' && github.event_name == 'pull_request'
       with:
         lcov-file: ./coverage.lcov
         lcov-base: ./main.lcov
@@ -82,7 +82,7 @@ jobs:
     needs: ["deps"]
     strategy:
       matrix:
-        version: ['1.18.0', '1.18.1']
+        version: ['1.22.0']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -92,8 +92,8 @@ jobs:
         go-version: ${{ matrix.version }}
     - name: Static check
       if: github.event_name == 'pull_request'
-      uses: dominikh/staticcheck-action@v1.2.0
+      uses: dominikh/staticcheck-action@v1.3.1
       with:
-        version: "2022.1.1"
+        version: "2023.1.7"
         install-go: false
         cache-key: ${{ matrix.go }}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # hoff: Higher Order Functions (and Friends) [![Go Reference](https://pkg.go.dev/badge/github.com/Shopify/hoff.svg)](https://pkg.go.dev/github.com/Shopify/hoff)
 
-Golang 1.18+ implementations of common methods/data structures using Go Generics
+Golang 1.22+ implementations of common methods/data structures using Go Generics
 
 ## Requirements
 
-- Go 1.18 or newer (must support Generics)
+- Go 1.22 or newer
 
 ## In Development
 

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require github.com/stretchr/testify v1.7.1
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,5 +7,6 @@ github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMT
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
There are a number of CVEs present in go versions < 1.21.1; updating to 1.22 now as a precaution

Signed-off-by: Samuel Dufel <samuel.dufel@shopify.com>
